### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ FROM node:20.15.1-alpine AS builder
 
 WORKDIR /app
 
-# Define build arguments with default values
-ARG NEXT_PUBLIC_API_URL=https://api-evoai.evoapicloud.com
-
 # Install dependencies first (caching)
 COPY package.json package-lock.json ./
 RUN npm ci
@@ -13,18 +10,12 @@ RUN npm ci
 # Copy source code
 COPY . .
 
-# Set environment variables from build arguments
-ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
-
 RUN npm run build
 
 # Production stage
 FROM node:20.15.1-alpine AS runner
 
 WORKDIR /app
-
-# Define build arguments again for the runner stage
-ARG NEXT_PUBLIC_API_URL=https://api-evoai.evoapicloud.com
 
 # Install production dependencies only
 COPY package.json package-lock.json ./
@@ -38,10 +29,9 @@ COPY --from=builder /app/next.config.mjs ./
 # Set environment variables
 ENV NODE_ENV=production
 ENV PORT=3000
-ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
 
 # Expose port
 EXPOSE 3000
 
 # Start the application
-CMD ["npm", "start"] 
+CMD ["npm", "start"]


### PR DESCRIPTION
Ajustado o Dockerfile para permitir a definição da variável de ambiente NEXT_PUBLIC_API_URL em tempo de execução, evitando a necessidade de construir uma nova imagem personalizada para cada ambiente de instalação.

## Summary by Sourcery

Enable runtime configuration of NEXT_PUBLIC_API_URL by removing hardcoded build-time arguments and environment variables from the Dockerfile.

Enhancements:
- Allow setting NEXT_PUBLIC_API_URL at runtime without rebuilding the Docker image.

Build:
- Remove NEXT_PUBLIC_API_URL build arguments and default values from both builder and runner stages.
- Eliminate ENV declarations for NEXT_PUBLIC_API_URL to defer value assignment to container runtime.